### PR TITLE
Fix import error for X icon in Vercel deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.vercel

--- a/src/lib/components/Footer/index.tsx
+++ b/src/lib/components/Footer/index.tsx
@@ -2,7 +2,7 @@ import NewsletterForm from '@/lib/components/Footer/NewsletterForm';
 import LandingPageIcon from '@/lib/components/LandingPageIcon';
 import linkedInIcon from '@/lib/icons/linkedin.svg';
 import openSourceEconomyLogo from '@/lib/icons/open-source-logo.svg';
-import xIcon from '@/lib/icons/x.svg';
+import xIcon from '@/lib/icons/X.svg';
 import youtubeIcon from '@/lib/icons/youtube.svg';
 
 const Footer = () => (


### PR DESCRIPTION
Fixes case-sensitive import issue that caused deployment failures on Vercel.

Key changes:
- Fixed X icon import path from 'x.svg' to 'X.svg' to match actual filename
- Added .vercel directory to .gitignore

The case-sensitive file system on Vercel was causing the import to fail, preventing successful deployment.